### PR TITLE
beautify the header, bring elements in line

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,7 +22,7 @@ export default {
   },
   mounted() {
     if (localStorage.getItem('darkMode')) {
-      this.isUsingDarkMode = (localStorage.getItem('darkMode') === 'true')
+      this.isUsingDarkMode = localStorage.getItem('darkMode') === 'true'
     }
   },
   methods: {
@@ -39,32 +39,25 @@ export default {
 
 .container {
   max-width: 1100px;
-  margin: 0 auto;
+  margin: 40px auto;
   min-height: 100vh;
 }
 .outer {
+  font-family: Calibri, sans-serif;
+  line-height: 1.7;
   .router-link-exact-active {
-    color: blue;
+    font-weight: 700;
   }
 }
-  i {
-    color: black;
-  }
+
 .darkMode {
   background-color: @dm-background;
   color: @dm-font-color;
   a {
     color: @dm-font-color;
   }
-    i {
+  .toggle {
     color: #f3d642;
   }
-  .router-link-exact-active {
-    color: lightpink;
-  }
-  a:hover {
-    color: black
-  }
 }
-
 </style>

--- a/src/_settings.less
+++ b/src/_settings.less
@@ -4,26 +4,9 @@
 @dm-background: rgba(42, 42, 46, 1);
 @dm-font-color: white;
 
-@keyframes button {
-  from {
-    background-color: white;
-  }
-  to {
-    background-color: hotpink;
-  }
-}
-
 .flexbox-property {
   display: flex;
   justify-content: space-around;
   margin: 10px auto;
   border-bottom: 1px solid @font-color-main;
-}
-
-.hover {
-  //   color: black;
-  animation-name: button;
-  animation-duration: 2s;
-  animation-fill-mode: forwards;
-  // font-weight: bold;
 }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -11,8 +11,9 @@
       >
       <router-link to="/contact">Contact</router-link>
     </nav>
-    <a @click="toggleDM" class="toggle"><i :class="setToggleIcon" aria-hidden="true" />
-</a>
+    <a @click="toggleDM" class="toggle"
+      ><i :class="setToggleIcon" aria-hidden="true" />
+    </a>
   </header>
 </template>
 
@@ -22,7 +23,7 @@ export default {
   props: {
     isUsingDarkMode: {
       type: Boolean,
-      required: true
+      required: true,
     },
     toggleDM: {
       type: Function,
@@ -32,8 +33,8 @@ export default {
   computed: {
     setToggleIcon() {
       return this.isUsingDarkMode ? 'fa fa-sun-o' : 'fa fa-moon-o'
-    }
-  }
+    },
+  },
 }
 </script>
 
@@ -43,23 +44,48 @@ export default {
 header {
   .flexbox-property();
   margin: 0;
-  padding: 20px 0;
   nav {
-    margin: 0 auto;
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    flex-grow: 1;
   }
   a {
     text-decoration: none;
     color: inherit;
     padding: 20px 15px;
-    // test github commit
+    position: relative;
+    &:after {
+      transition: width 0.5s;
+      width: 0%;
+      position: absolute;
+      content: '';
+      height: 2px;
+      bottom: 15px;
+      margin: 0 auto;
+      left: 0;
+      right: 0;
+    }
+    &:hover:after {
+      animation-name: underline;
+      animation-duration: 0.5s;
+      animation-fill-mode: forwards;
+      background-color: #f2e5d7;
+      width: 40%;
+    }
   }
-  .toggle {
-    // position: absolute;
-    float: right;
+
+  @keyframes underline {
+    from {
+      background-color: #f2e5d7;
+      width: 40%;
+    }
+    to {
+      background-color: #ffbcb5;
+      width: 80%;
+    }
   }
-  a:hover {
-    .hover();
-  }
+
   @media only screen and (max-width: 360px) {
     margin: 0px;
     nav {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -122,9 +122,6 @@ export default {}
       margin: 0 15px;
       display: block;
     }
-    a:hover {
-      .hover();
-    }
   }
   @media only screen and (max-width: 500px) {
     flex-direction: column;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3733911/97670458-84ea2300-1a43-11eb-8a60-bdacf9ba8cf1.png)

- Bring the dark mode toggle in line with the rest of the header
- Change the nav item hover state to an animated underline
- Change the nav item active state to bolded
- Change the site font and line height